### PR TITLE
Non-Erroring JSON Matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,22 @@ function jsonMatching(actual, expected) {
   return { pass: equals(actual, expected) };
 }
 
-expect.extend({ jsonMatching, toMatchJSON });
+function jsonMatchingNoParseError(actual, expected) {
+  const _this = expect.jsonMatchingNoParseError();
+  if (typeof actual !== "string") {
+    throw Error(
+      `You must provide a string to ${_this.toString()}, not '${typeof actual}'.`
+    );
+  }
+  try {
+    actual = JSON.parse(actual);
+    return { pass: equals(actual, expected) };
+  } catch (err) {
+    return { pass: equals(false, true) };
+  }
+}
+
+expect.extend({ jsonMatchingNoParseError, jsonMatching, toMatchJSON });
 
 /**
  * Formats the JSON.parse error message

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const diff = require("jest-diff");
-const { equals } = require("expect/build/jasmine_utils");
+const { equals } = require("expect/build/jasmineUtils");
 const { isOneline } = require("expect/build/utils");
 const {
   RECEIVED_COLOR,
@@ -96,12 +96,6 @@ function jsonMatching(actual, expected) {
 }
 
 function jsonMatchingNoParseError(actual, expected) {
-  const _this = expect.jsonMatchingNoParseError();
-  if (typeof actual !== "string") {
-    throw Error(
-      `You must provide a string to ${_this.toString()}, not '${typeof actual}'.`
-    );
-  }
   try {
     actual = JSON.parse(actual);
     return { pass: equals(actual, expected) };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "eslint . && prettier --list-different README.md && jest"
   },
   "dependencies": {
-    "expect": "^23.0.0",
+    "expect": "^24.9.0",
     "jest-diff": "^23.0.0",
     "jest-matcher-utils": "^23.0.0"
   },
@@ -27,8 +27,11 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.2",
     "has-ansi": "^3.0.0",
-    "jest": "^23.4.1",
+    "jest": "24.9.0",
     "prettier": "^1.13.7",
     "strip-ansi": "^4.0.0"
+  },
+  "peerDependencies": {
+    "jest": "^24.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -63,3 +63,49 @@ describe("jsonMatching", () => {
     }).toThrow(/Actual is not valid JSON/);
   });
 });
+
+describe("jsonMatchingNoParseError", () => {
+  test("matches object", () => {
+    expect(JSON.stringify({ foo: "bar" })).toEqual(
+      expect.jsonMatchingNoParseError({
+        foo: expect.any(String)
+      })
+    );
+
+    expect(JSON.stringify({ foo: "bar", bar: "baz" })).toEqual(
+      expect.jsonMatchingNoParseError(expect.objectContaining({ foo: "bar" }))
+    );
+  });
+
+  test("matches array", () => {
+    expect(JSON.stringify(["foo", "bar"])).toEqual(
+      expect.jsonMatchingNoParseError(expect.arrayContaining(["bar", "foo"]))
+    );
+  });
+
+  test("does not error when encountering non-parsable JSON, permitting group matching", () => {
+    expect([
+      "not-json",
+      "{ invalid: JSON ]",
+      JSON.stringify({ valid: "JSON" })
+    ]).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("not-json"),
+        expect.stringContaining("invalid"),
+        expect.jsonMatchingNoParseError({ valid: "JSON" })
+      ])
+    );
+
+    expect(() =>
+      expect([
+        "not-json",
+        "{ invalid: JSON ]",
+        JSON.stringify({ valid: "JSON" })
+      ]).toEqual(
+        expect.arrayContaining([
+          expect.jsonMatchingNoParseError({ different: "JSON" })
+        ])
+      )
+    ).toThrowError();
+  });
+});

--- a/test.js
+++ b/test.js
@@ -83,7 +83,7 @@ describe("jsonMatchingNoParseError", () => {
     );
   });
 
-  test("does not error when encountering non-parsable JSON, permitting group matching", () => {
+  test("does not error when encountering non-parsable string, permitting group matching", () => {
     expect([
       "not-json",
       "{ invalid: JSON ]",
@@ -95,7 +95,24 @@ describe("jsonMatchingNoParseError", () => {
         expect.jsonMatchingNoParseError({ valid: "JSON" })
       ])
     );
+  });
 
+  test("throws for non-strings", () => {
+    expect(() =>
+      expect([
+        false,
+        "not-json",
+        "{ invalid: JSON ]",
+        JSON.stringify({ valid: "JSON" })
+      ]).toEqual(
+        expect.arrayContaining([
+          expect.jsonMatchingNoParseError({ valid: "JSON" })
+        ])
+      )
+    ).toThrowError();
+  });
+
+  test("throws when no JSON match is found", () => {
     expect(() =>
       expect([
         "not-json",

--- a/test.js
+++ b/test.js
@@ -83,33 +83,25 @@ describe("jsonMatchingNoParseError", () => {
     );
   });
 
-  test("does not error when encountering non-parsable string, permitting group matching", () => {
+  test("does not error when encountering invalid JSON, permitting group matching", () => {
     expect([
+      1,
+      null,
+      false,
       "not-json",
+      { a: "property" },
       "{ invalid: JSON ]",
       JSON.stringify({ valid: "JSON" })
     ]).toEqual(
       expect.arrayContaining([
+        expect.toEqual(1),
+        expect.toEqual(null),
         expect.stringContaining("not-json"),
-        expect.stringContaining("invalid"),
+        expect.stringContaining("invalid: JSON"),
+        expect.objectContaining({ a: "property" }),
         expect.jsonMatchingNoParseError({ valid: "JSON" })
       ])
     );
-  });
-
-  test("throws for non-strings", () => {
-    expect(() =>
-      expect([
-        false,
-        "not-json",
-        "{ invalid: JSON ]",
-        JSON.stringify({ valid: "JSON" })
-      ]).toEqual(
-        expect.arrayContaining([
-          expect.jsonMatchingNoParseError({ valid: "JSON" })
-        ])
-      )
-    ).toThrowError();
   });
 
   test("throws when no JSON match is found", () => {


### PR DESCRIPTION
## Description
We need to be able to handle non-deterministic orders in our JSON structures and this matcher is exactly what we need.

### The Problem
Unfortunately, the asymmetric matcher doesn't currently work when used inside Jest's [arrayContaining](https://jestjs.io/docs/en/expect#expectarraycontainingarray) to check for equality on one of the array items.

This is because the current `jsonMatching` function throws an error if any of the entries cannot be parsed by `JSON.parse`.

### A Solution
This PR adds an equivalent function `jsonMatchingNoParseError` - _the name is absolutely changeable_ - just the best one I could think of for the time being.

This function has the same functionality as `jsonMatching`, except it does not throw an error if the current item cannot be parsed. Instead, it returns a `pass` function that always fails, namely `equals(false, true)` - _this is also totally changeable_.

Originally I intended to set the `actual` result value in the `catch` block to `null`, but that would be an arbitrary value and could catch people out if they want to assert against a value of `null`. This would incorrectly produce a false-positive.

I look forward to your thoughts @duailibe, thanks in advance!