### PR TITLE
Fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   interface Matchers<R> {
-    toMatchJSON(expected: Record<string, unknown>): R;
+    toMatchJSON(expected: any): R;
   }
 
   interface Expect {


### PR DESCRIPTION
If we restrict `toMatchJSON` to only accept records, we can't actually compare arrays. 
At the moment, compiling `expect("[]").toMatchJSON([])` fails.

Setting `expected` to any should fix that.