### PR TITLE
[breaking] Remove dependency on expect

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
-        jest-version: [24, 25, 26, 27]
+        jest-version: [27]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      # Copied from jest-extended
-      - name: install with jest@${{ matrix.jest-version }}
-        run: yarn add jest@${{ matrix.jest-version }} babel-jest@${{ matrix.jest-version }} pretty-format@${{ matrix.jest-version }} @types/jest@${{ matrix.jest-version }}
-      - run: yarn jest --coverage
+      - run: yarn install
+      - run: npx jest@${{ matrix.jest-version }} --coverage
       - uses: codecov/codecov-action@v2
 
   lint:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Jest matchers to work with JSON strings.
 
 ## Setup
 
+**Note:** If you're using Jest < 27.2.5, you should stick to `jest-json@^1.0`.
+
 Add `jest-json` to your Jest config:
 
 ```json

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const { equals } = require("expect/build/jasmineUtils");
-
 const errorMarker = "__INTERNALERRORMARKER__";
 
 /**
@@ -61,7 +59,7 @@ function toMatchJSON(received, expected) {
     );
   }
 
-  const pass = equals(received, expected);
+  const pass = this.equals(received, expected);
   const message = pass
     ? () =>
         `${hint} \n\nExpected: not ${printExpected(expected)}` +
@@ -95,7 +93,7 @@ function jsonMatching(received, expected) {
   let pass = false;
   try {
     received = JSON.parse(received);
-    pass = equals(received, expected);
+    pass = this.equals(received, expected);
   } catch (err) {} // eslint-disable-line no-empty
   return { pass };
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "lint": "eslint .",
     "test": "npx jest"
   },
+  "peerDependencies": {
+    "jest": ">=27.2.5"
+  },
   "devDependencies": {
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,12 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "jest"
-  },
-  "dependencies": {
-    "expect": "^27.2.4"
+    "test": "npx jest"
   },
   "devDependencies": {
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "jest": "^27.4.3",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-snapshot-serializer-raw": "^1.2.0",
     "prettier": "^2.5.1"


### PR DESCRIPTION
Since [Jest 27.2.5](https://github.com/facebook/jest/blob/main/CHANGELOG.md#2725) the matcher context is included in asymmetric matchers as well, so we can remove a dependency on expect.

Marking this as a breaking change as it will affect anyone on Jest < 27.2.5